### PR TITLE
block_size and vect_size as runtime options of stream benchmark

### DIFF
--- a/neuromapp/compression/main.cpp
+++ b/neuromapp/compression/main.cpp
@@ -75,6 +75,8 @@ int comp_execute(int argc,char *const argv[])
             ("kernel_measure","run increasingly complex calculations on block comparing timing performance tradeoff for compression")
             ("stream_benchmark","use a McCalpin STREAM inspired set of benchmarks to measure bandwith on the computer")
          ("numthread", po::value<int>()->default_value(1), "number of OMP thread")
+         ("block_size", po::value<int>()->default_value(8000), "size of a block in the stream benchmark")
+         ("vect_size", po::value<int>()->default_value(640), "number of blocks in a vector, in the stream benchmark")
          ("benchmark","run all of the files in data directory, create csv with output stats");
         //create variable map
         po::variables_map vm;

--- a/neuromapp/compression/main_functions.h
+++ b/neuromapp/compression/main_functions.h
@@ -93,13 +93,13 @@ void stream_bench_routine(po::variables_map vm) {
     //must run the stream bench a separate time without the split argument provided for comparison
     if (vm.count("split")) {
         if (vm.count("compress")) {
-            binary_stream_vectors<value_type,allocator_type> vectors(true);
+            binary_stream_vectors<value_type,allocator_type> vectors(true, vm["block_size"].as<int>(), vm["vect_size"].as<int>());
             copy_benchmark<binary_stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
             scale_benchmark<binary_stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
             add_benchmark<binary_stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
             triad_benchmark<binary_stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
         } else {
-            binary_stream_vectors<value_type,allocator_type> vectors(false);
+            binary_stream_vectors<value_type,allocator_type> vectors(false, vm["block_size"].as<int>(), vm["vect_size"].as<int>());
             copy_benchmark<binary_stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
             scale_benchmark<binary_stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
             add_benchmark<binary_stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
@@ -108,13 +108,13 @@ void stream_bench_routine(po::variables_map vm) {
 
     } else {
         if (vm.count("compress")){
-            stream_vectors<value_type,allocator_type> vectors(true);
+            stream_vectors<value_type,allocator_type> vectors(true, vm["block_size"].as<int>(), vm["vect_size"].as<int>());
             copy_benchmark<stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
             scale_benchmark<stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
             add_benchmark<stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
             triad_benchmark<stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
         } else {
-            stream_vectors<value_type,allocator_type> vectors(false);
+            stream_vectors<value_type,allocator_type> vectors(false, vm["block_size"].as<int>(), vm["vect_size"].as<int>());
             copy_benchmark<stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
             scale_benchmark<stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;
             add_benchmark<stream_vectors<value_type,allocator_type>,value_type,allocator_type> (vectors) ;

--- a/neuromapp/compression/stream_benchmark.h
+++ b/neuromapp/compression/stream_benchmark.h
@@ -60,17 +60,17 @@ namespace neuromapp {
     template <typename value_type,typename allocator_type> 
         class binary_stream_vectors {
             typedef typename Conv_info<value_type>::bytetype binary_rep;
-            const static size_type block_size =  8000;
+            const size_type block_size;
             size_type block_mem_size;
             bool compress_opt = false;
-            const static int vect_size = 640;
+            const int vect_size;
             /*this is the number of times that we run each benchmark computation before taking the minimum time*/
             vector<block<binary_rep,allocator_type>> v_a;
             vector<block<binary_rep,allocator_type>> v_b;
             vector<block<binary_rep,allocator_type>> v_c;
             // calculation results section
             public:
-            binary_stream_vectors(bool compress_arg) : compress_opt{compress_arg}  {
+            binary_stream_vectors (bool compress_arg, int block_size, int vec_size) : block_size(block_size), compress_opt{compress_arg}, vect_size(vec_size) {
 //#pragma omp parallel for
                 for (int i = 0 ; i < vect_size; i++) {
                     block<value_type,allocator_type> ba(block_size);
@@ -140,17 +140,17 @@ namespace neuromapp {
 
     template <typename value_type,typename allocator_type> 
         class stream_vectors {
-            const static size_type block_size =  8000;
+            const size_type block_size;
             size_type block_mem_size;
             bool compress_opt;
-            const static int vect_size = 640;
+            const int vect_size;
             /*this is the number of times that we run each benchmark computation before taking the minimum time*/
             vector<block<value_type,allocator_type>> v_a;
             vector<block<value_type,allocator_type>> v_b;
             vector<block<value_type,allocator_type>> v_c;
             // calculation results section
             public:
-            stream_vectors (bool compress_arg) : compress_opt{compress_arg} {
+            stream_vectors (bool compress_arg, int block_size, int vec_size) : block_size(block_size), compress_opt{compress_arg}, vect_size(vec_size) {
 //#pragma omp parallel for
                 for (int i = 0 ; i < vect_size; i++) {
                     block<value_type,allocator_type> ba(block_size);


### PR DESCRIPTION
Slight changes to allow to pass block_size and vect_size as command line options when executing stream benchmark.